### PR TITLE
Feature/sim 1852/test file size

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,3 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+scripts.BasicSConstruct("sims_maps")

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,0 +1,5 @@
+# -*- python -*-
+import os
+from lsst.sconsUtils import scripts, env
+
+scripts.BasicSConscript.tests()

--- a/tests/testFileSize.py
+++ b/tests/testFileSize.py
@@ -1,0 +1,49 @@
+import numpy as np
+import os
+import unittest
+import lsst.utils.tests as utilsTests
+from lsst.utils import getPackageDir
+
+class MapSizeUnitTest(unittest.TestCase):
+
+    longMessage = True
+
+
+    def testDustMaps(self):
+        mb = 1024*1024
+        kb = 1024
+        control_size_dict = {'SFD_dust_4096_ngp.fits':64*mb,
+                             'SFD_dust_4096_sgp.fits':64*mb,
+                             'dust_nside_1024.npz':96*mb,
+                             'dust_nside_128.npz':1.5*mb,
+                             'dust_nside_16.npz':24*kb,
+                             'dust_nside_2.npz':582,
+                             'dust_nside_256.npz':6*mb,
+                             'dust_nside_32.npz':96*kb,
+                             'dust_nside_4.npz':1.7*kb,
+                             'dust_nside_512.npz':24*mb,
+                             'dust_nside_64.npz':384*kb,
+                             'dust_nside_8.npz':6.2*kb}
+
+        root_dir = getPackageDir('sims_maps')
+        for file_name in control_size_dict:
+            full_name = os.path.join(root_dir, 'DustMaps', file_name)
+            size = os.path.getsize(full_name)
+            self.assertLess(np.abs(size-control_size_dict[file_name]),
+                            0.1*control_size_dict[file_name],
+                            msg='\nYou may not have git-lfs installed\n'+
+                            'on your system\n'+
+                            'http://developer.lsst.io/en/latest/tools/git_lfs.html')
+
+
+def suite():
+    utilsTests.init()
+    suites = []
+    suites += unittest.makeSuite(MapSizeUnitTest)
+    return unittest.TestSuite(suites)
+
+def run(shouldExit=False):
+    utilsTests.run(suite(),shouldExit)
+
+if __name__ == "__main__":
+    run(True)

--- a/tests/testFileSize.py
+++ b/tests/testFileSize.py
@@ -5,12 +5,20 @@ import lsst.utils.tests as utilsTests
 from lsst.utils import getPackageDir
 
 class MapSizeUnitTest(unittest.TestCase):
+    """
+    Check that the files in this package are as large as we would expect
+    if git-lfs worked properly
+    """
 
     longMessage = True
 
 
     def testDustMaps(self):
-        mb = 1024*1024
+        """
+        Go through contents of DustMaps directory and check that files
+        are the size we expect them to be.
+        """
+        mb = 1024*1024 # because os.path.getsize returns the size in bytes
         kb = 1024
         control_size_dict = {'SFD_dust_4096_ngp.fits':64*mb,
                              'SFD_dust_4096_sgp.fits':64*mb,

--- a/tests/testFileSize.py
+++ b/tests/testFileSize.py
@@ -12,6 +12,11 @@ class MapSizeUnitTest(unittest.TestCase):
 
     longMessage = True
 
+    def setUp(self):
+        self.lfs_msg='\nYou may not have git-lfs installed\n' + \
+                     'on your system\n' + \
+                     'http://developer.lsst.io/en/latest/tools/git_lfs.html'
+
 
     def testDustMaps(self):
         """
@@ -39,9 +44,21 @@ class MapSizeUnitTest(unittest.TestCase):
             size = os.path.getsize(full_name)
             self.assertLess(np.abs(size-control_size_dict[file_name]),
                             0.1*control_size_dict[file_name],
-                            msg='\nYou may not have git-lfs installed\n'+
-                            'on your system\n'+
-                            'http://developer.lsst.io/en/latest/tools/git_lfs.html')
+                            msg=self.lfs_msg)
+
+
+    def testStarMaps(self):
+        """
+        Test that the files in the StarMaps directory are all several
+        megabytes in size
+        """
+
+        root_dir = os.path.join(getPackageDir('sims_maps'), 'StarMaps')
+        list_of_files = os.listdir(root_dir)
+        for file_name in list_of_files:
+            full_name = os.path.join(root_dir, file_name)
+            self.assertGreater(os.path.getsize(full_name), 1024*1024,
+                               msg=self.lfs_msg)
 
 
 def suite():

--- a/tests/testFileSize.py
+++ b/tests/testFileSize.py
@@ -13,7 +13,7 @@ class MapSizeUnitTest(unittest.TestCase):
     longMessage = True
 
     def setUp(self):
-        self.lfs_msg='\nYou may not have git-lfs installed\n' + \
+        self.lfs_msg='\nYou may not have git-lfs installed ' + \
                      'on your system\n' + \
                      'http://developer.lsst.io/en/latest/tools/git_lfs.html'
 

--- a/ups/sims_maps.cfg
+++ b/ups/sims_maps.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = dict(
+    required = [],
+)
+
+config = lsst.sconsUtils.Configuration(
+    __file__,
+    libs=[],
+    hasDoxygenInclude=False,
+    hasSwigFiles=False,
+)

--- a/ups/sims_maps.table
+++ b/ups/sims_maps.table
@@ -1,0 +1,2 @@
+setupRequired(python)
+setupRequired(utils)


### PR DESCRIPTION
This pull request adds tests that verify that the file sizes in the various sub-directories are what we expect on a system where git-lfs was properly installed.  A message about git-lfs is appended to the failure message in the event that file sizes come back too small.