### PR TITLE
[DM-10478] Add setupRequired(numpy) to sims_maps.table.

### DIFF
--- a/ups/sims_maps.table
+++ b/ups/sims_maps.table
@@ -1,1 +1,2 @@
+setupRequired(numpy)
 setupRequired(python)


### PR DESCRIPTION
Only `tests/testFileSize.py` uses numpy, but this omission breaks `conda-lsst`.

	modified:   ups/sims_maps.table